### PR TITLE
Update tests to use tempdir() and to unlink when done

### DIFF
--- a/inst/tinytest/test_epitrax.R
+++ b/inst/tinytest/test_epitrax.R
@@ -397,3 +397,6 @@ if (at_home()) {
   expect_equal(length(list.files(fsys$public)), 7)
 
 }
+
+# Cleanup after tests (NO TESTS AFTER THIS STEP) -------------------------------
+unlink(unlist(fsys, use.names = FALSE), recursive = TRUE)


### PR DESCRIPTION
This pull request refactors the tests in `inst/tinytest/test_filesystem.R` to consistently use temporary directories for filesystem operations, improving test isolation and cleanup. It also adds explicit cleanup steps to both `test_filesystem.R` and `test_epitrax.R` to ensure no leftover files or directories remain after tests are run.

**Filesystem test refactoring and cleanup:**

* All references to hardcoded folder names have been replaced with dynamically created temporary directories via the `test_folders` list, ensuring tests do not interfere with the local filesystem.
* All test file operations (creation, copying, deletion, and checking existence) now use paths from the `test_folders` list, improving consistency and reliability. [[1]](diffhunk://#diff-9a248f7f9ffc964aad1da0f57cfa257c0868f91ec088cba9a901c39849f50aadL2-R31) [[2]](diffhunk://#diff-9a248f7f9ffc964aad1da0f57cfa257c0868f91ec088cba9a901c39849f50aadR141-R154) [[3]](diffhunk://#diff-9a248f7f9ffc964aad1da0f57cfa257c0868f91ec088cba9a901c39849f50aadL174-R171)
* The explicit cleanup code at the end of `test_filesystem.R` now removes all temporary directories using a single `unlink(unlist(test_folders, use.names = FALSE), recursive = TRUE)` call, replacing multiple individual `unlink` calls.

**Test setup improvements:**

* The test setup for `setup_filesystem()` now uses the same temporary directory structure, removing redundant redefinitions and ensuring a clean test environment for each run. [[1]](diffhunk://#diff-9a248f7f9ffc964aad1da0f57cfa257c0868f91ec088cba9a901c39849f50aadL38-L43) [[2]](diffhunk://#diff-9a248f7f9ffc964aad1da0f57cfa257c0868f91ec088cba9a901c39849f50aadL68-L72)

**General test hygiene:**

* Added a cleanup step at the end of `test_epitrax.R` to remove all files and directories created during the tests, preventing leftover test artifacts.