### PR TITLE
Use %||% operator for default NULL values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epitraxr
 Title: Manipulate Epitrax Data And Generate Reports
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: c(
     person(given = "Andrew", family = "Pulsipher", email = "pulsipher.a@gmail.com",
         role = c("aut", "cre"), comment = c(ORCID = "0000-0002-0773-3210")),

--- a/R/data.R
+++ b/R/data.R
@@ -61,7 +61,7 @@ format_week_num <- function(data) {
 read_epitrax_data <- function(data_file = NULL) {
 
   # If data_file is provided, use it; otherwise, prompt user to choose a file
-  fpath <- ifelse(!is.null(data_file), data_file, file.choose())
+  fpath <- data_file %||% file.choose()
 
   if (!file.exists(fpath) || !grepl("\\.csv$", fpath)) {
     stop("Please select an EpiTrax data file (.csv).")

--- a/R/epitrax.R
+++ b/R/epitrax.R
@@ -53,9 +53,7 @@ epitrax_set_config_from_list <- function(epitrax, config = NULL) {
 
     validate_epitrax(epitrax, report.check = FALSE)
 
-    if (is.null(config)) {
-        config <- list()
-    }
+    config <- config %||% list()
 
     if (inherits(config, "list")) {
         epitrax$config <- do.call(epitraxr_config, config)


### PR DESCRIPTION
This pull request updates the `epitraxr` package to version 0.3.4 and introduces minor improvements to the codebase, mainly focused on simplifying default value handling. The changes enhance code readability and maintainability by replacing explicit conditional logic with the more idiomatic `%||%` operator in R.

Version update:

* Updated the package version in the `DESCRIPTION` file from 0.3.3 to 0.3.4 to reflect the new release.

Codebase simplification:

* Refactored the file selection logic in `read_epitrax_data` (in `R/data.R`) to use the `%||%` operator for cleaner handling of default values.
* Simplified the configuration assignment in `epitrax_set_config_from_list` (in `R/epitrax.R`) by replacing an explicit `is.null` check with the `%||%` operator.