### PR TITLE
Fix bug with epitrax_write_xlsxs()

### DIFF
--- a/R/epitrax.R
+++ b/R/epitrax.R
@@ -865,18 +865,22 @@ epitrax_write_xlsxs <- function(epitrax, fsys) {
     validate_filesystem(fsys)
 
     # Write internal reports to Excel
-    write_report_xlsx(
-        data = epitrax$internal_reports,
-        filename = "internal_reports_combined.xlsx",
-        folder = fsys$internal
-    )
+    if (length(epitrax$internal_reports) > 0) {
+        write_report_xlsx(
+            data = epitrax$internal_reports,
+            filename = "internal_reports_combined.xlsx",
+            folder = fsys$internal
+        )
+    }
 
     # Write public reports to Excel
-    write_report_xlsx(
-        data = epitrax$public_reports,
-        filename = "public_reports_combined.xlsx",
-        folder = fsys$public
-    )
+    if (length(epitrax$public_reports) > 0) {
+        write_report_xlsx(
+            data = epitrax$public_reports,
+            filename = "public_reports_combined.xlsx",
+            folder = fsys$public
+        )
+    }
 
     epitrax
 }

--- a/inst/tinytest/test_epitrax.R
+++ b/inst/tinytest/test_epitrax.R
@@ -295,6 +295,15 @@ fsys <- list(
 )
 setup_filesystem(fsys, clear.reports = TRUE)
 
+# Test when internal and public reports are empty
+epitrax_empty <- epitrax
+epitrax_empty$internal_reports <- list()
+epitrax_empty$public_reports <- list()
+expect_silent(epitrax_write_xlsxs(epitrax_empty, fsys = fsys))
+expect_equal(length(list.files(fsys$internal)), 0)
+expect_equal(length(list.files(fsys$public)), 0)
+
+# Test with actual internal and public reports
 # - Check overall results
 epitrax <- epitrax_write_xlsxs(epitrax, fsys = fsys)
 


### PR DESCRIPTION
This pull request improves the robustness of the `epitrax_write_xlsxs` function and adds new tests to ensure correct behavior when report lists are empty. The changes prevent unnecessary file writing and verify that no files are created when there are no reports.

Function logic improvements:

* Added checks in `epitrax_write_xlsxs` to only write internal and public reports to Excel if their respective report lists are non-empty, preventing creation of empty files.

Test enhancements:

* Added tests in `inst/tinytest/test_epitrax.R` to verify that no files are written when both `internal_reports` and `public_reports` are empty, using `expect_silent` and `expect_equal` assertions.