### PR TITLE
Update how package handles extracting X yrs of data from intput

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -1,11 +1,12 @@
 #' Format input EpiTrax data
 #'
 #' 'format_week_num' formats the input EpiTrax dataset with month numbers
-#' using the field 'patient_mmwr_week' and filters rows older than five years.
+#' using the field 'patient_mmwr_week'.
 #'
 #' @param data Dataframe. Data to format.
 #'
-#' @returns The formatted data.
+#' @returns The formatted data with columns "disease", "month", "year",
+#' and "counts".
 #' @export
 #'
 #' @importFrom lubridate month ymd
@@ -25,16 +26,14 @@ format_week_num <- function(data) {
   # - Rearrange columns for easier debugging
   data <- data[c("disease", "month", "year", "counts")]
 
-  # - Extract last years of data
-  data <- with(data, data[year >= (max(year) - 5), ])
-
   data
 }
 
 #' Read in input EpiTrax data
 #'
-#' 'read_epitrax_data' reads EpiTrax data from a CSV, validates and formats it,
-#' then returns the data. The file must contain the columns:
+#' 'read_epitrax_data' reads EpiTrax data from a CSV, validates, and formats it.
+#' It also filters rows older than given number of years. The input file must
+#' contain the columns:
 #' - patient_mmwr_year: The year of the MMWR week
 #' - patient_mmwr_week: The MMWR week number
 #' - patient_disease: The disease name
@@ -43,6 +42,7 @@ format_week_num <- function(data) {
 #'
 #' @param data_file Optional filepath. Data file should be a CSV. If this parameter
 #' is NULL, the user will be prompted to choose a file interactively.
+#' @param num_yrs Integer. Number of years of data to keep. Defaults to 5.
 #'
 #' @returns The validated and formatted EpiTrax data from the input file.
 #' @export
@@ -56,9 +56,16 @@ format_week_num <- function(data) {
 #' }
 #'
 #' # Using a file path:
-#' read_epitrax_data(system.file("sample_data/sample_epitrax_data.csv",
-#'                               package = "epitraxr"))
-read_epitrax_data <- function(data_file = NULL) {
+#' read_epitrax_data(
+#'  data_file = system.file("sample_data/sample_epitrax_data.csv",
+#'                          package = "epitraxr"),
+#'  num_yrs = 3
+#' )
+read_epitrax_data <- function(data_file = NULL, num_yrs = 5) {
+
+  if (is.null(num_yrs) || !is.numeric(num_yrs) || num_yrs < 0) {
+    stop("In 'read_epitrax_data', 'num_yrs' must be an integer >= 0.")
+  }
 
   # If data_file is provided, use it; otherwise, prompt user to choose a file
   fpath <- data_file %||% file.choose()
@@ -74,6 +81,9 @@ read_epitrax_data <- function(data_file = NULL) {
   data <- validate_data(data)
   data <- format_week_num(data)
 
+  # Extract last x years of data
+  data <- with(data, data[year >= (max(year) - num_yrs), ])
+
   # Return data from file
   data
 }
@@ -86,6 +96,7 @@ read_epitrax_data <- function(data_file = NULL) {
 #'
 #' @param data_file Optional filepath. Data file should be a CSV. If this parameter
 #'   is NULL, the user will be prompted to choose a file interactively.
+#' @param num_yrs Integer. Number of years of data to keep. Defaults to 5.
 #'
 #' @returns An object of class "epitrax" containing:
 #'   - data: The validated and formatted EpiTrax data
@@ -112,9 +123,9 @@ read_epitrax_data <- function(data_file = NULL) {
 #' head(epitrax$data)
 #' epitrax$diseases
 #' epitrax$report_year
-get_epitrax <- function(data_file = NULL) {
+get_epitrax <- function(data_file = NULL, num_yrs = 5) {
   # Read in EpiTrax data
-  epitrax_data <- read_epitrax_data(data_file)
+  epitrax_data <- read_epitrax_data(data_file, num_yrs = num_yrs)
 
   # Compute common summary statistics and metadata
   data_diseases <- unique(epitrax_data$disease)

--- a/R/epitrax.R
+++ b/R/epitrax.R
@@ -124,6 +124,7 @@ epitrax_add_report_diseases <- function(epitrax, disease_list_files = NULL) {
 #'
 #' @param epitrax_file Optional path to the EpiTrax data file. Data file should
 #' be a CSV. If omitted, the user will be prompted to choose a file interactively.
+#' @param num_yrs Integer. Number of years of data to keep. Defaults to 5.
 #' @param disease_list_files Optional list containing filepaths to internal and
 #' public report disease lists. If omitted, the default lists will be used and
 #' a warning will be thrown.
@@ -149,7 +150,7 @@ epitrax_add_report_diseases <- function(epitrax, disease_list_files = NULL) {
 #'   epitrax_file = data_file,
 #'   disease_list_files = disease_lists
 #' )
-setup_epitrax <- function(epitrax_file = NULL, disease_list_files = NULL, config_list = NULL, config_file = NULL) {
+setup_epitrax <- function(epitrax_file = NULL, num_yrs = 5, disease_list_files = NULL, config_list = NULL, config_file = NULL) {
 
     if (!is.null(config_list) && !is.null(config_file)) {
         stop(
@@ -158,7 +159,7 @@ setup_epitrax <- function(epitrax_file = NULL, disease_list_files = NULL, config
         )
     }
 
-    epitrax <- get_epitrax(epitrax_file) |>
+    epitrax <- get_epitrax(epitrax_file, num_yrs = num_yrs) |>
         epitrax_add_report_diseases(disease_list_files)
 
     if (!is.null(config_file)) {

--- a/inst/tinytest/test_data.R
+++ b/inst/tinytest/test_data.R
@@ -13,19 +13,30 @@ res <- format_week_num(input)
 
 expect_equal(colnames(res), expected_cols)
 expect_true(all(res$counts == 1))
-expect_equal(nrow(res), 6) # 7 years - 1 year filtered out
-expect_true(all(res$year >= max(input$patient_mmwr_year) - 5))
 
 
 # Test read_epitrax_data() -----------------------------------------------------
 
 # Test with valid file
 test_file <- "test_files/data/test_epitrax_data.csv"
+
+# - Check with num_yrs = 4 (should filter out 1 year)
+res <- read_epitrax_data(test_file, num_yrs = 4)
+expect_equal(nrow(res), 22337)
+expect_true(all(res$year >= max(res$year) - 4))
+
+# - Check with num_yrs = 0 (should include only latest year)
+res <- read_epitrax_data(test_file, num_yrs = 0)
+expect_equal(nrow(res), 3522)
+expect_true(all(res$year == max(res$year)))
+
+# - Check with default num_yrs (5 years)
 res <- read_epitrax_data(test_file)
 
 expect_true(is.data.frame(res))
 expect_equal(nrow(res), 24683)
 expect_equal(res$year[1], 2020)
+expect_true(all(res$year >= max(res$year) - 5))
 
 # Test with non-existent file
 expect_error(read_epitrax_data("/tmp/this_file_does_not_exist.csv"),
@@ -37,6 +48,16 @@ file.create(wrong_file)
 expect_error(read_epitrax_data(wrong_file),
              "Please select an EpiTrax data file \\(.csv\\)\\.")
 unlink(wrong_file)
+
+# Test with invalid num_yrs
+expect_error(read_epitrax_data(test_file, num_yrs = -1),
+             "'num_yrs' must be an integer >= 0")
+expect_error(read_epitrax_data(test_file, num_yrs = NA),
+             "'num_yrs' must be an integer >= 0")
+expect_error(read_epitrax_data(test_file, num_yrs = "not a number"),
+             "'num_yrs' must be an integer >= 0")
+expect_error(read_epitrax_data(test_file, num_yrs = NULL),
+             "'num_yrs' must be an integer >= 0")
 
 
 # Test get_epitrax() ---------------------------------------------------------

--- a/man/format_week_num.Rd
+++ b/man/format_week_num.Rd
@@ -10,11 +10,12 @@ format_week_num(data)
 \item{data}{Dataframe. Data to format.}
 }
 \value{
-The formatted data.
+The formatted data with columns "disease", "month", "year",
+and "counts".
 }
 \description{
 'format_week_num' formats the input EpiTrax dataset with month numbers
-using the field 'patient_mmwr_week' and filters rows older than five years.
+using the field 'patient_mmwr_week'.
 }
 \examples{
 df <- data.frame(patient_mmwr_year=2020L, patient_mmwr_week=1L, patient_disease="A")

--- a/man/get_epitrax.Rd
+++ b/man/get_epitrax.Rd
@@ -4,11 +4,13 @@
 \alias{get_epitrax}
 \title{Create an EpiTrax object from data file}
 \usage{
-get_epitrax(data_file = NULL)
+get_epitrax(data_file = NULL, num_yrs = 5)
 }
 \arguments{
 \item{data_file}{Optional filepath. Data file should be a CSV. If this parameter
 is NULL, the user will be prompted to choose a file interactively.}
+
+\item{num_yrs}{Integer. Number of years of data to keep. Defaults to 5.}
 }
 \value{
 An object of class "epitrax" containing:

--- a/man/read_epitrax_data.Rd
+++ b/man/read_epitrax_data.Rd
@@ -4,18 +4,21 @@
 \alias{read_epitrax_data}
 \title{Read in input EpiTrax data}
 \usage{
-read_epitrax_data(data_file = NULL)
+read_epitrax_data(data_file = NULL, num_yrs = 5)
 }
 \arguments{
 \item{data_file}{Optional filepath. Data file should be a CSV. If this parameter
 is NULL, the user will be prompted to choose a file interactively.}
+
+\item{num_yrs}{Integer. Number of years of data to keep. Defaults to 5.}
 }
 \value{
 The validated and formatted EpiTrax data from the input file.
 }
 \description{
-'read_epitrax_data' reads EpiTrax data from a CSV, validates and formats it,
-then returns the data. The file must contain the columns:
+'read_epitrax_data' reads EpiTrax data from a CSV, validates, and formats it.
+It also filters rows older than given number of years. The input file must
+contain the columns:
 \itemize{
 \item patient_mmwr_year: The year of the MMWR week
 \item patient_mmwr_week: The MMWR week number
@@ -31,6 +34,9 @@ read_epitrax_data()
 }
 
 # Using a file path:
-read_epitrax_data(system.file("sample_data/sample_epitrax_data.csv",
-                              package = "epitraxr"))
+read_epitrax_data(
+ data_file = system.file("sample_data/sample_epitrax_data.csv",
+                         package = "epitraxr"),
+ num_yrs = 3
+)
 }

--- a/man/setup_epitrax.Rd
+++ b/man/setup_epitrax.Rd
@@ -6,6 +6,7 @@
 \usage{
 setup_epitrax(
   epitrax_file = NULL,
+  num_yrs = 5,
   disease_list_files = NULL,
   config_list = NULL,
   config_file = NULL
@@ -14,6 +15,8 @@ setup_epitrax(
 \arguments{
 \item{epitrax_file}{Optional path to the EpiTrax data file. Data file should
 be a CSV. If omitted, the user will be prompted to choose a file interactively.}
+
+\item{num_yrs}{Integer. Number of years of data to keep. Defaults to 5.}
 
 \item{disease_list_files}{Optional list containing filepaths to internal and
 public report disease lists. If omitted, the default lists will be used and


### PR DESCRIPTION
This pull request introduces a configurable option for filtering EpiTrax data by the number of years to retain, replacing the previous fixed five-year filter. The change propagates through the main data reading, object creation, and setup functions, and is reflected in documentation and tests. This makes the codebase more flexible for users who want to analyze different time windows of epidemiological data.

**Filtering and Data Processing Enhancements:**

* Added a `num_yrs` parameter to `read_epitrax_data`, `get_epitrax`, and `setup_epitrax` functions, allowing users to specify how many years of data to keep (default is 5). Input validation ensures `num_yrs` is a non-negative integer. [[1]](diffhunk://#diff-678570ee915c22103f88e26e5e17d10478906c2306c2cc7c01c1b00a308e4171L59-R68) [[2]](diffhunk://#diff-678570ee915c22103f88e26e5e17d10478906c2306c2cc7c01c1b00a308e4171L115-R128) [[3]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eL152-R153)
* Moved the year-based filtering logic from `format_week_num` to `read_epitrax_data`, so the filter is applied after formatting and validation, and is now controlled via the new parameter. [[1]](diffhunk://#diff-678570ee915c22103f88e26e5e17d10478906c2306c2cc7c01c1b00a308e4171L28-R36) [[2]](diffhunk://#diff-678570ee915c22103f88e26e5e17d10478906c2306c2cc7c01c1b00a308e4171R84-R86)

**Documentation Updates:**

* Updated Roxygen and Rd documentation for `format_week_num`, `read_epitrax_data`, `get_epitrax`, and `setup_epitrax` to describe the new `num_yrs` parameter and clarify return values. [[1]](diffhunk://#diff-678570ee915c22103f88e26e5e17d10478906c2306c2cc7c01c1b00a308e4171L4-R9) [[2]](diffhunk://#diff-678570ee915c22103f88e26e5e17d10478906c2306c2cc7c01c1b00a308e4171R45) [[3]](diffhunk://#diff-678570ee915c22103f88e26e5e17d10478906c2306c2cc7c01c1b00a308e4171R99) [[4]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eR127) [[5]](diffhunk://#diff-6da44cb07c3f93ef2b67111dd71ca3ef1807c693e5d39c55736e6eaf511dd321R9) [[6]](diffhunk://#diff-6da44cb07c3f93ef2b67111dd71ca3ef1807c693e5d39c55736e6eaf511dd321R19-R20) [[7]](diffhunk://#diff-1cad7b65b6d09f54b268cb1f4599aa211f15da2dcb0318b0794040a651baf121L13-R18) [[8]](diffhunk://#diff-6fc341d1c6230fd68276a61f08ee0205d1c8043182712bcdad88956f39805226L7-R13) [[9]](diffhunk://#diff-6bb3ecd3bd9a2670d07da2d8b38773c0987a6b047ff227c74dc8b321ae4b6c8bL7-R21)

**Testing Improvements:**

* Expanded unit tests to cover various `num_yrs` scenarios, including edge cases (e.g., zero years, invalid values), ensuring that filtering works as expected and errors are raised for invalid input. [[1]](diffhunk://#diff-d648088fdfe3944c18eb67857d4892ad58edf946df972065719b65b58c5afd9aL16-R39) [[2]](diffhunk://#diff-d648088fdfe3944c18eb67857d4892ad58edf946df972065719b65b58c5afd9aR52-R61)

**Example and Usage Updates:**

* Updated usage examples in documentation to show how to use the new `num_yrs` parameter when reading and processing EpiTrax data.

**Setup and Integration:**

* Propagated the new `num_yrs` parameter through the setup pipeline, allowing users to control data filtering from the top-level `setup_epitrax` function. [[1]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eL152-R153) [[2]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eL161-R162)

These changes make the package more flexible and robust for users analyzing epidemiological data over custom time periods.