### PR TITLE
Increase maximum file size to 30MB

### DIFF
--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -149,6 +149,8 @@ ui <- shiny::fluidPage(
 # Define server logic
 server <- function(input, output, session) {
 
+  options(shiny.maxRequestSize = 30 * 1024^2)
+
   # Reactive values to store data and reports
   epitrax_obj <- shiny::reactiveVal(NULL)
 


### PR DESCRIPTION
This pull request makes a small configuration change to the Shiny application, increasing the maximum allowed request size for file uploads.

* Increased the `shiny.maxRequestSize` option to 30 MB in the server logic of `inst/app/app.R`, allowing users to upload larger files.