### PR TITLE
Add option for trend-only PDF reports

### DIFF
--- a/R/epitrax.R
+++ b/R/epitrax.R
@@ -896,6 +896,7 @@ epitrax_write_xlsxs <- function(epitrax, fsys) {
 #'
 #' @param epitrax Object of class `epitrax`.
 #' @param fsys Filesystem list containing path for public reports.
+#' @param trend.only Logical. Whether to show only trend in the PDF report.
 #'
 #' @returns The original EpiTrax object, unchanged.
 #' @export
@@ -926,7 +927,7 @@ epitrax_write_xlsxs <- function(epitrax, fsys) {
 #'   epitrax_preport_month_crosssections(month_offsets = 0) |>
 #'   epitrax_write_pdf_public_reports(fsys = fsys)
 #' }
-epitrax_write_pdf_public_reports <- function(epitrax, fsys) {
+epitrax_write_pdf_public_reports <- function(epitrax, fsys, trend.only = FALSE) {
 
     validate_epitrax(epitrax)
     validate_filesystem(fsys)
@@ -949,7 +950,8 @@ epitrax_write_pdf_public_reports <- function(epitrax, fsys) {
             data = report,
             params = params,
             filename = paste0(name, ".pdf"),
-            folder = fsys$public
+            folder = fsys$public,
+            trend.only = trend.only
         )
 
     }
@@ -968,6 +970,7 @@ epitrax_write_pdf_public_reports <- function(epitrax, fsys) {
 #' @param params List. Report parameters containing:
 #'   - title: Report title (defaults to "Grouped Report")
 #' @param fsys Filesystem list containing paths for internal and public reports.
+#' @param trend.only Logical. Whether to show only trend in the PDF report.
 #'
 #' @returns The original EpiTrax object, unchanged.
 #' @export
@@ -1003,7 +1006,7 @@ epitrax_write_pdf_public_reports <- function(epitrax, fsys) {
 #'   epitrax_report_grouped_stats() |>
 #'   epitrax_write_pdf_grouped_stats(params = params, fsys = fsys)
 #' }
-epitrax_write_pdf_grouped_stats <- function(epitrax, params, fsys) {
+epitrax_write_pdf_grouped_stats <- function(epitrax, params, fsys, trend.only = FALSE) {
 
     validate_epitrax(epitrax)
     validate_filesystem(fsys)
@@ -1024,7 +1027,8 @@ epitrax_write_pdf_grouped_stats <- function(epitrax, params, fsys) {
             data = report,
             params = params,
             filename = paste0(name, ".pdf"),
-            folder = fsys$internal
+            folder = fsys$internal,
+            trend.only = trend.only
         )
     }
 
@@ -1040,7 +1044,8 @@ epitrax_write_pdf_grouped_stats <- function(epitrax, params, fsys) {
             data = report,
             params = params,
             filename = paste0(name, ".pdf"),
-            folder = fsys$public
+            folder = fsys$public,
+            trend.only = trend.only
         )
     }
 

--- a/R/filesystem.R
+++ b/R/filesystem.R
@@ -258,6 +258,8 @@ write_report_xlsx <- function(data, filename, folder) {
 #'   - trend_threshold: Threshold for trend calculations (defaults to 0.15)
 #' @param filename String. Output filename for the rendered report.
 #' @param folder Filepath. Output directory for the rendered report.
+#' @param trend.only Logical. Whether to show only trend in the PDF report.
+#' If TRUE, "trend_only_" will be prepended to the filename.
 #'
 #' @returns NULL (called for side effects - creates the report file).
 #' @export
@@ -296,7 +298,7 @@ write_report_xlsx <- function(data, filename, folder) {
 #'    folder = tempdir()
 #'  )
 #' }
-write_grouped_report_pdf <- function(data, params, filename, folder) {
+write_grouped_report_pdf <- function(data, params, filename, folder, trend.only = FALSE) {
   # Check if rmarkdown is available
   if (!requireNamespace("rmarkdown", quietly = TRUE)) {
     stop(
@@ -316,6 +318,11 @@ write_grouped_report_pdf <- function(data, params, filename, folder) {
     dir.create(folder, recursive = TRUE)
   }
 
+  # Correct filename if trend.only is TRUE
+  corrected_filename <- ifelse(trend.only,
+                              paste0("trend_only_", filename),
+                              filename)
+
   # Render the report
   rmarkdown::render(
     input = template_path,
@@ -324,9 +331,10 @@ write_grouped_report_pdf <- function(data, params, filename, folder) {
       report_year = params$report_year %||% 2025,
       report_month = params$report_month %||% 1,
       trend_threshold = params$trend_threshold %||% 0.15,
-      report_data = data
+      report_data = data,
+      trend_only = trend.only
     ),
-    output_file = filename,
+    output_file = corrected_filename,
     output_dir = folder,
     quiet = TRUE,
     envir = new.env(parent = globalenv())
@@ -348,6 +356,8 @@ write_grouped_report_pdf <- function(data, params, filename, folder) {
 #'   - trend_threshold: Threshold for trend calculations (defaults to 0.15)
 #' @param filename String. Output filename for the rendered report.
 #' @param folder Filepath. Output directory for the rendered report.
+#' @param trend.only Logical. Whether to show only trend in the PDF report.
+#' If TRUE, "trend_only_" will be prepended to the filename.
 #'
 #' @returns NULL (called for side effects - creates the report file).
 #' @export
@@ -380,7 +390,7 @@ write_grouped_report_pdf <- function(data, params, filename, folder) {
 #'    folder = tempdir()
 #'  )
 #' }
-write_report_pdf <- function(data, params, filename, folder) {
+write_report_pdf <- function(data, params, filename, folder, trend.only = FALSE) {
   # Check if rmarkdown is available
   if (!requireNamespace("rmarkdown", quietly = TRUE)) {
     stop(
@@ -400,6 +410,11 @@ write_report_pdf <- function(data, params, filename, folder) {
     dir.create(folder, recursive = TRUE)
   }
 
+  # Correct filename if trend.only is TRUE
+  corrected_filename <- ifelse(trend.only,
+                               paste0("trend_only_", filename),
+                               filename)
+
   # Render the report
   rmarkdown::render(
     input = template_path,
@@ -408,9 +423,10 @@ write_report_pdf <- function(data, params, filename, folder) {
       report_year = params$report_year %||% 2025,
       report_month = params$report_month %||% 1,
       trend_threshold = params$trend_threshold %||% 0.15,
-      report_data = data
+      report_data = data,
+      trend_only = trend.only
     ),
-    output_file = filename,
+    output_file = corrected_filename,
     output_dir = folder,
     quiet = TRUE,
     envir = new.env(parent = globalenv())

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -195,7 +195,8 @@ server <- function(input, output, session) {
       shiny::showNotification(
         "Generating reports...",
         type = "message",
-        duration = 2
+        duration = NULL,
+        id = "report_progress_notification"
       )
 
       # Create config list from frontend inputs
@@ -279,6 +280,8 @@ server <- function(input, output, session) {
       shinyjs::enable("download_pdf")
       shinyjs::enable("download_all")
 
+      # Show progress
+      shiny::removeNotification(id = "report_progress_notification")
       shiny::showNotification("Reports generated successfully!", type = "message")
 
     }, error = function(e) {
@@ -305,7 +308,8 @@ server <- function(input, output, session) {
       shiny::showNotification(
         "Generating CSVs...",
         type = "message",
-        duration = 2
+        duration = NULL,
+        id = "csv_progress_notification"
       )
 
       # Create temporary directory
@@ -353,6 +357,7 @@ server <- function(input, output, session) {
         unlink(csv_dir, recursive = TRUE)
 
         # Show progress
+        shiny::removeNotification(id = "csv_progress_notification")
         shiny::showNotification("CSVs generated successfully!", type = "message")
 
       }, error = function(e) {
@@ -374,7 +379,8 @@ server <- function(input, output, session) {
       shiny::showNotification(
         "Generating Excel files...",
         type = "message",
-        duration = 2
+        duration = NULL,
+        id = "excel_progress_notification"
       )
 
       # Create temporary directory
@@ -432,6 +438,7 @@ server <- function(input, output, session) {
         unlink(excel_dir, recursive = TRUE)
 
         # Show progress
+        shiny::removeNotification(id = "excel_progress_notification")
         shiny::showNotification("Excel files generated successfully!", type = "message")
 
       }, error = function(e) {
@@ -562,10 +569,10 @@ server <- function(input, output, session) {
 
       # Show progress
       shiny::showNotification(
-        "Generating PDFs...",
+        "Generating CSV, Excel, and PDF files...",
         type = "message",
         duration = NULL,
-        id = "pdf_progress_notification"
+        id = "all_progress_notification"
       )
 
       # Create temporary directory
@@ -720,8 +727,8 @@ server <- function(input, output, session) {
         unlink(all_dir, recursive = TRUE)
 
         # Show progress
-        shiny::removeNotification(id = "pdf_progress_notification")
-        shiny::showNotification("PDFs generated successfully!", type = "message")
+        shiny::removeNotification(id = "all_progress_notification")
+        shiny::showNotification("Files generated successfully!", type = "message")
 
       }, error = function(e) {
         shiny::showNotification(paste("Error creating combined download:", e$message), type = "error")

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -342,6 +342,9 @@ server <- function(input, output, session) {
         utils::zip(file, zip_name, flags = "-r")
         setwd(old_wd)
 
+        # Clear generated reports
+        unlink(csv_dir, recursive = TRUE)
+
       }, error = function(e) {
         shiny::showNotification(paste("Error creating CSV download:", e$message), type = "error")
       })
@@ -408,6 +411,9 @@ server <- function(input, output, session) {
         utils::zip(file, zip_name, flags = "-r")
         setwd(old_wd)
 
+        # Clear generated reports
+        unlink(excel_dir, recursive = TRUE)
+
       }, error = function(e) {
         shiny::showNotification(paste("Error creating Excel download:", e$message), type = "error")
       })
@@ -441,9 +447,7 @@ server <- function(input, output, session) {
         )
 
         # Create directories
-        dir.create(fsys$internal, showWarnings = FALSE, recursive = TRUE)
-        dir.create(fsys$public, showWarnings = FALSE, recursive = TRUE)
-        dir.create(fsys$settings, showWarnings = FALSE, recursive = TRUE)
+        setup_filesystem(fsys, clear.reports = TRUE)
 
         # PDF report parameters
         params <- list(
@@ -489,7 +493,7 @@ server <- function(input, output, session) {
           }
         }
 
-        # Remove empty directories
+        # Remove empty directories (so they don't appear in zip archive)
         if (length(list.files(fsys$internal)) == 0) {
           unlink(fsys$internal, recursive = TRUE)
         }
@@ -503,6 +507,11 @@ server <- function(input, output, session) {
         setwd(temp_dir)
         utils::zip(file, zip_name, flags = "-r")
         setwd(old_wd)
+
+        # Clear generated reports
+        unlink(fsys$internal, recursive = TRUE)
+        unlink(fsys$public, recursive = TRUE)
+        unlink(fsys$settings, recursive = TRUE)
 
       }, error = function(e) {
         shiny::showNotification(paste("Error creating PDF download:", e$message), type = "error")
@@ -607,9 +616,7 @@ server <- function(input, output, session) {
         )
 
         # Create directories
-        dir.create(pdf_fsys$internal, showWarnings = FALSE, recursive = TRUE)
-        dir.create(pdf_fsys$public, showWarnings = FALSE, recursive = TRUE)
-        dir.create(pdf_fsys$settings, showWarnings = FALSE, recursive = TRUE)
+        setup_filesystem(pdf_fsys, clear.reports = TRUE)
 
         # PDF report parameters
         params <- list(
@@ -651,7 +658,7 @@ server <- function(input, output, session) {
           }
         }
 
-        # Remove empty PDF directories
+        # Remove empty PDF directories (so they don't appear in zip archive)
         if (length(list.files(pdf_fsys$internal)) == 0) {
           unlink(pdf_fsys$internal, recursive = TRUE)
         }
@@ -668,6 +675,9 @@ server <- function(input, output, session) {
         setwd(temp_dir)
         utils::zip(file, zip_name, flags = "-r")
         setwd(old_wd)
+
+        # Clear generated reports
+        unlink(all_dir, recursive = TRUE)
 
       }, error = function(e) {
         shiny::showNotification(paste("Error creating combined download:", e$message), type = "error")

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -301,6 +301,13 @@ server <- function(input, output, session) {
     content = function(file) {
       shiny::req(epitrax_obj())
 
+      # Show progress
+      shiny::showNotification(
+        "Generating CSVs...",
+        type = "message",
+        duration = 2
+      )
+
       # Create temporary directory
       temp_dir <- tempdir()
       # Create a directory with the same name as the ZIP file (without extension)
@@ -345,6 +352,9 @@ server <- function(input, output, session) {
         # Clear generated reports
         unlink(csv_dir, recursive = TRUE)
 
+        # Show progress
+        shiny::showNotification("CSVs generated successfully!", type = "message")
+
       }, error = function(e) {
         shiny::showNotification(paste("Error creating CSV download:", e$message), type = "error")
       })
@@ -359,6 +369,13 @@ server <- function(input, output, session) {
     },
     content = function(file) {
       shiny::req(epitrax_obj())
+
+      # Show progress
+      shiny::showNotification(
+        "Generating Excel files...",
+        type = "message",
+        duration = 2
+      )
 
       # Create temporary directory
       temp_dir <- tempdir()
@@ -414,6 +431,9 @@ server <- function(input, output, session) {
         # Clear generated reports
         unlink(excel_dir, recursive = TRUE)
 
+        # Show progress
+        shiny::showNotification("Excel files generated successfully!", type = "message")
+
       }, error = function(e) {
         shiny::showNotification(paste("Error creating Excel download:", e$message), type = "error")
       })
@@ -428,6 +448,14 @@ server <- function(input, output, session) {
     },
     content = function(file) {
       shiny::req(epitrax_obj())
+
+      # Show progress
+      shiny::showNotification(
+        "Generating PDFs...",
+        type = "message",
+        duration = NULL,
+        id = "pdf_progress_notification"
+      )
 
       # Create temporary directory
       temp_dir <- tempdir()
@@ -513,6 +541,10 @@ server <- function(input, output, session) {
         unlink(fsys$public, recursive = TRUE)
         unlink(fsys$settings, recursive = TRUE)
 
+        # Show progress
+        shiny::removeNotification(id = "pdf_progress_notification")
+        shiny::showNotification("PDFs generated successfully!", type = "message")
+
       }, error = function(e) {
         shiny::showNotification(paste("Error creating PDF download:", e$message), type = "error")
       })
@@ -527,6 +559,14 @@ server <- function(input, output, session) {
     },
     content = function(file) {
       shiny::req(epitrax_obj())
+
+      # Show progress
+      shiny::showNotification(
+        "Generating PDFs...",
+        type = "message",
+        duration = NULL,
+        id = "pdf_progress_notification"
+      )
 
       # Create temporary directory
       temp_dir <- tempdir()
@@ -678,6 +718,10 @@ server <- function(input, output, session) {
 
         # Clear generated reports
         unlink(all_dir, recursive = TRUE)
+
+        # Show progress
+        shiny::removeNotification(id = "pdf_progress_notification")
+        shiny::showNotification("PDFs generated successfully!", type = "message")
 
       }, error = function(e) {
         shiny::showNotification(paste("Error creating combined download:", e$message), type = "error")

--- a/inst/report_formats/general_report.Rmd
+++ b/inst/report_formats/general_report.Rmd
@@ -6,6 +6,7 @@ params:
     report_month: 1
     trend_threshold: 0.15
     report_data: NULL
+    trend_only: FALSE
 header-includes:
 - \usepackage{booktabs}
 - \usepackage{longtable}
@@ -44,7 +45,38 @@ if (r_threshold < 0 | r_threshold > 1) {
     r_threshold <- 0.15
 }
 
-if (length(names(r_data)) == 8) {
+if(params$trend_only) {
+    r_data <- r_data[, c("Disease", "Trend")]
+
+    kbl(
+        r_data,
+        col.names = c(
+            "Disease",
+            paste0("Trend", footnote_marker_symbol(1))
+        ),
+        booktabs = TRUE,
+        align = "ll",
+        escape = FALSE
+        ) |>
+        kable_styling(
+            latex_options = c("scale_down")
+        ) |>
+        column_spec(
+            2,
+            background = ifelse(
+                r_data$Trend == "Elevated", "red",
+                ifelse(r_data$Trend == "Expected", "yellow",
+                "green"))
+        ) |>
+        footnote(symbol = c(
+            paste0(
+                "A percent change of ",
+                r_threshold * 100,
+                "% or more will result in a change in the trend"
+            )
+            ))
+    
+} else if (length(names(r_data)) == 8) {
     # Set header row from input parameters
     # This workaround is needed to dynamically create the header names
     header_2 <- c(3, 4)

--- a/inst/report_formats/grouped_report.Rmd
+++ b/inst/report_formats/grouped_report.Rmd
@@ -7,6 +7,7 @@ params:
     report_month: 1
     trend_threshold: 0.15
     report_data: NULL
+    trend_only: FALSE
 header-includes:
 - \usepackage{booktabs}
 - \usepackage{longtable}
@@ -46,7 +47,54 @@ if (r_threshold < 0 | r_threshold > 1) {
     r_threshold <- 0.15
 }
 
-if (length(names(r_data)) == 10) {
+# Trend-only report
+if (params$trend_only) {
+    r_data <- r_data[, c("Group", "Disease", "YTD Trend")]
+
+    kbl(
+        r_data[,2:3],
+        row.names = FALSE,
+        col.names = c(
+            "Disease",
+            paste0(
+                r_year,
+                " YTD",  
+                footnote_marker_symbol(1),
+                " Trend",
+                footnote_marker_symbol(2)
+            )
+        ),
+        booktabs = TRUE,
+        longtable = TRUE,
+        caption = params$title,
+        align = "ll",
+        escape = FALSE
+        ) |>
+        kable_styling(
+            font_size = 7,
+            latex_options = c("scale_down", "repeat_header")
+        ) |>
+        column_spec(
+            2,
+            background = ifelse(
+                r_data$`YTD Trend` == "Elevated", "red",
+                ifelse(r_data$`YTD Trend` == "Expected", "yellow",
+                "green"))
+        ) |>
+        pack_rows(
+            index = table(r_data$Group),
+            latex_gap_space = "1em"
+        ) |>
+        footnote(symbol = c(
+            "Year-to-Date",
+            paste0(
+                "Trend is computed by comparing the current YTD to the historical YTD average. A percent change of ",
+                r_threshold * 100,
+                "% or more will result in a change in the trend."
+            )
+        ))
+
+} else if (length(names(r_data)) == 10) { # Full report
     # Set header row from input parameters
     # This workaround is needed to dynamically create the header names
     header_2 <- c(2, 2, 1, 2)
@@ -107,7 +155,6 @@ if (length(names(r_data)) == 10) {
                 "% or more will result in a change in the trend."
             )
             ))
-        
 }
 ```
 

--- a/man/epitrax_write_pdf_grouped_stats.Rd
+++ b/man/epitrax_write_pdf_grouped_stats.Rd
@@ -4,7 +4,7 @@
 \alias{epitrax_write_pdf_grouped_stats}
 \title{Write grouped statistics reports from EpiTrax object to PDF files}
 \usage{
-epitrax_write_pdf_grouped_stats(epitrax, params, fsys)
+epitrax_write_pdf_grouped_stats(epitrax, params, fsys, trend.only = FALSE)
 }
 \arguments{
 \item{epitrax}{Object of class \code{epitrax}.}
@@ -15,6 +15,8 @@ epitrax_write_pdf_grouped_stats(epitrax, params, fsys)
 }}
 
 \item{fsys}{Filesystem list containing paths for internal and public reports.}
+
+\item{trend.only}{Logical. Whether to show only trend in the PDF report.}
 }
 \value{
 The original EpiTrax object, unchanged.

--- a/man/epitrax_write_pdf_public_reports.Rd
+++ b/man/epitrax_write_pdf_public_reports.Rd
@@ -4,12 +4,14 @@
 \alias{epitrax_write_pdf_public_reports}
 \title{Create formatted PDF report of monthly cross-section reports}
 \usage{
-epitrax_write_pdf_public_reports(epitrax, fsys)
+epitrax_write_pdf_public_reports(epitrax, fsys, trend.only = FALSE)
 }
 \arguments{
 \item{epitrax}{Object of class \code{epitrax}.}
 
 \item{fsys}{Filesystem list containing path for public reports.}
+
+\item{trend.only}{Logical. Whether to show only trend in the PDF report.}
 }
 \value{
 The original EpiTrax object, unchanged.

--- a/man/write_grouped_report_pdf.Rd
+++ b/man/write_grouped_report_pdf.Rd
@@ -4,7 +4,7 @@
 \alias{write_grouped_report_pdf}
 \title{Write PDF grouped report from R Markdown template}
 \usage{
-write_grouped_report_pdf(data, params, filename, folder)
+write_grouped_report_pdf(data, params, filename, folder, trend.only = FALSE)
 }
 \arguments{
 \item{data}{Dataframe. Report data containing grouped disease statistics.}
@@ -20,6 +20,9 @@ write_grouped_report_pdf(data, params, filename, folder)
 \item{filename}{String. Output filename for the rendered report.}
 
 \item{folder}{Filepath. Output directory for the rendered report.}
+
+\item{trend.only}{Logical. Whether to show only trend in the PDF report.
+If TRUE, "trend_only_" will be prepended to the filename.}
 }
 \value{
 NULL (called for side effects - creates the report file).

--- a/man/write_report_pdf.Rd
+++ b/man/write_report_pdf.Rd
@@ -4,7 +4,7 @@
 \alias{write_report_pdf}
 \title{Write general PDF report of disease stats from R Markdown template}
 \usage{
-write_report_pdf(data, params, filename, folder)
+write_report_pdf(data, params, filename, folder, trend.only = FALSE)
 }
 \arguments{
 \item{data}{Dataframe. Report data containing disease statistics.}
@@ -20,6 +20,9 @@ write_report_pdf(data, params, filename, folder)
 \item{filename}{String. Output filename for the rendered report.}
 
 \item{folder}{Filepath. Output directory for the rendered report.}
+
+\item{trend.only}{Logical. Whether to show only trend in the PDF report.
+If TRUE, "trend_only_" will be prepended to the filename.}
 }
 \value{
 NULL (called for side effects - creates the report file).

--- a/scripts/test-format.R
+++ b/scripts/test-format.R
@@ -42,11 +42,22 @@ epitrax <- setup_epitrax(
   epitrax_write_pdf_public_reports(
     fsys = fsys
   ) |>
+  epitrax_write_pdf_public_reports(
+    fsys = fsys,
+    trend.only = TRUE
+  ) |>
   epitrax_write_pdf_grouped_stats(
     params = list(
       title = "Grouped Disease Surveillance Report"
     ),
     fsys = fsys
+  ) |>
+  epitrax_write_pdf_grouped_stats(
+    params = list(
+      title = "Disease Trend Report (Grouped)"
+    ),
+    fsys = fsys,
+    trend.only = TRUE
   )
 
 message(".......Done.")


### PR DESCRIPTION
This pull request introduces a new "Trend Only" feature for PDF report generation in the EpiTrax reporting system and improves user feedback during report generation in the Shiny app. The most important changes include support for generating trend-only PDF reports (with filename and template parameter adjustments), updates to the Shiny app UI to allow users to select "Trend Only" options, and enhanced progress notifications for report generation. Additionally, there are improvements to internal report generation logic and cleanup of temporary files and directories.

### Trend Only PDF Report Generation

* Added a new `trend.only` logical parameter to PDF report generation functions (`epitrax_write_pdf_public_reports`, `epitrax_write_pdf_grouped_stats`, `write_report_pdf`, and `write_grouped_report_pdf`). When enabled, this option modifies the filename to prepend "trend_only_" and passes the setting to the report template. [[1]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eR899) [[2]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eL929-R930) [[3]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eL952-R954) [[4]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eR973) [[5]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eL1006-R1009) [[6]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eL1027-R1031) [[7]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eL1043-R1048) [[8]](diffhunk://#diff-736c36a15bcb8b9d176499582a4e6dd4748085a0c52a27ac3d8a9c4dec29a873R261-R262) [[9]](diffhunk://#diff-736c36a15bcb8b9d176499582a4e6dd4748085a0c52a27ac3d8a9c4dec29a873L299-R301) [[10]](diffhunk://#diff-736c36a15bcb8b9d176499582a4e6dd4748085a0c52a27ac3d8a9c4dec29a873R321-R325) [[11]](diffhunk://#diff-736c36a15bcb8b9d176499582a4e6dd4748085a0c52a27ac3d8a9c4dec29a873L327-R337) [[12]](diffhunk://#diff-736c36a15bcb8b9d176499582a4e6dd4748085a0c52a27ac3d8a9c4dec29a873R359-R360) [[13]](diffhunk://#diff-736c36a15bcb8b9d176499582a4e6dd4748085a0c52a27ac3d8a9c4dec29a873L383-R393) [[14]](diffhunk://#diff-736c36a15bcb8b9d176499582a4e6dd4748085a0c52a27ac3d8a9c4dec29a873R413-R417) [[15]](diffhunk://#diff-736c36a15bcb8b9d176499582a4e6dd4748085a0c52a27ac3d8a9c4dec29a873L411-R429)

### Shiny App UI and User Experience

* Updated the Shiny app UI to include a checkbox group for users to select "Trend Only" PDF generation for internal and public reports.
* Improved progress notifications for report generation (CSVs, Excel files, PDFs) by showing and removing notifications at appropriate steps, and displaying success messages upon completion. [[1]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36L187-R199) [[2]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36R283-R284) [[3]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36R307-R314) [[4]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36R356-R362) [[5]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36R378-R385) [[6]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36R437-R443) [[7]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36R459-R466) [[8]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36R546-R554)

### Internal Report Generation Logic

* Refactored the report selection and generation logic to ensure grouped stats and median reports are generated in the correct order and only once. [[1]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36R249-R260) [[2]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36L250-L262)

### Filesystem and Cleanup Improvements

* Added a call to `setup_filesystem` to clear report directories before PDF generation, and improved cleanup by removing generated files and empty directories after zipping. [[1]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36L434-R485) [[2]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36L475-R531) [[3]](diffhunk://#diff-a86099534ef56992c830b560ebfbff30ffdc7cf2934cd6dadfe637f29c598d36R546-R554)

### Report Option Labeling

* Updated report option labels in the Shiny app to indicate whether each report is "internal" or "public" for better clarity.