### PR TITLE
Update README after CRAN acceptance

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,11 +17,12 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![ForeSITE Group](https://github.com/EpiForeSITE/software/raw/e82ed88f75e0fe5c0a1a3b38c2b94509f122019c/docs/assets/foresite-software-badge.svg)](https://github.com/EpiForeSITE)
+[![CRANlogs downloads](https://cranlogs.r-pkg.org/badges/grand-total/epitraxr)](https://cran.r-project.org/package=epitraxr)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/EpiForeSITE/epitraxr/blob/master/LICENSE.md)
 [![R-CMD-check](https://github.com/EpiForeSITE/epitraxr/actions/workflows/r-check.yaml/badge.svg)](https://github.com/EpiForeSITE/epitraxr/actions/workflows/r-check.yaml)
 [![pkgdown](https://github.com/EpiForeSITE/epitraxr/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/EpiForeSITE/epitraxr/actions/workflows/pkgdown.yaml)
-[![codecov](https://app.codecov.io/gh/EpiForeSITE/epitraxr/graph/badge.svg?token=KC48SFPX39)](https://app.codecov.io/gh/EpiForeSITE/epitraxr)
+[![codecov](https://codecov.io/gh/EpiForeSITE/epitraxr/graph/badge.svg?token=KC48SFPX39)](https://app.codecov.io/gh/EpiForeSITE/epitraxr)
 <!-- badges: end -->
 
 ## Overview

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,12 +17,12 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![ForeSITE Group](https://github.com/EpiForeSITE/software/raw/e82ed88f75e0fe5c0a1a3b38c2b94509f122019c/docs/assets/foresite-software-badge.svg)](https://github.com/EpiForeSITE)
-[![CRANlogs downloads](https://cranlogs.r-pkg.org/badges/grand-total/epitraxr)](https://cran.r-project.org/package=epitraxr)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/EpiForeSITE/epitraxr/blob/master/LICENSE.md)
 [![R-CMD-check](https://github.com/EpiForeSITE/epitraxr/actions/workflows/r-check.yaml/badge.svg)](https://github.com/EpiForeSITE/epitraxr/actions/workflows/r-check.yaml)
 [![pkgdown](https://github.com/EpiForeSITE/epitraxr/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/EpiForeSITE/epitraxr/actions/workflows/pkgdown.yaml)
 [![codecov](https://codecov.io/gh/EpiForeSITE/epitraxr/graph/badge.svg?token=KC48SFPX39)](https://app.codecov.io/gh/EpiForeSITE/epitraxr)
+[![CRANlogs downloads](https://cranlogs.r-pkg.org/badges/grand-total/epitraxr)](https://cran.r-project.org/package=epitraxr)
 <!-- badges: end -->
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@
 
 [![ForeSITE
 Group](https://github.com/EpiForeSITE/software/raw/e82ed88f75e0fe5c0a1a3b38c2b94509f122019c/docs/assets/foresite-software-badge.svg)](https://github.com/EpiForeSITE)
+[![CRANlogs
+downloads](https://cranlogs.r-pkg.org/badges/grand-total/epitraxr)](https://cran.r-project.org/package=epitraxr)
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![License:
 MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/EpiForeSITE/epitraxr/blob/master/LICENSE.md)
 [![R-CMD-check](https://github.com/EpiForeSITE/epitraxr/actions/workflows/r-check.yaml/badge.svg)](https://github.com/EpiForeSITE/epitraxr/actions/workflows/r-check.yaml)
 [![pkgdown](https://github.com/EpiForeSITE/epitraxr/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/EpiForeSITE/epitraxr/actions/workflows/pkgdown.yaml)
-[![codecov](https://app.codecov.io/gh/EpiForeSITE/epitraxr/graph/badge.svg?token=KC48SFPX39)](https://app.codecov.io/gh/EpiForeSITE/epitraxr)
+[![codecov](https://codecov.io/gh/EpiForeSITE/epitraxr/graph/badge.svg?token=KC48SFPX39)](https://app.codecov.io/gh/EpiForeSITE/epitraxr)
 <!-- badges: end -->
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 [![ForeSITE
 Group](https://github.com/EpiForeSITE/software/raw/e82ed88f75e0fe5c0a1a3b38c2b94509f122019c/docs/assets/foresite-software-badge.svg)](https://github.com/EpiForeSITE)
-[![CRANlogs
-downloads](https://cranlogs.r-pkg.org/badges/grand-total/epitraxr)](https://cran.r-project.org/package=epitraxr)
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![License:
@@ -16,6 +14,8 @@ MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Ep
 [![R-CMD-check](https://github.com/EpiForeSITE/epitraxr/actions/workflows/r-check.yaml/badge.svg)](https://github.com/EpiForeSITE/epitraxr/actions/workflows/r-check.yaml)
 [![pkgdown](https://github.com/EpiForeSITE/epitraxr/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/EpiForeSITE/epitraxr/actions/workflows/pkgdown.yaml)
 [![codecov](https://codecov.io/gh/EpiForeSITE/epitraxr/graph/badge.svg?token=KC48SFPX39)](https://app.codecov.io/gh/EpiForeSITE/epitraxr)
+[![CRANlogs
+downloads](https://cranlogs.r-pkg.org/badges/grand-total/epitraxr)](https://cran.r-project.org/package=epitraxr)
 <!-- badges: end -->
 
 ## Overview


### PR DESCRIPTION
This pull request updates the badges displayed at the top of the `README.md` and `README.Rmd` files to improve accuracy and provide additional information about the package. The most important changes are:

Badge updates:

* The Codecov badge URL was updated to use the canonical codecov.io domain for the badge image, ensuring correct display and reliability. (`README.md`, `README.Rmd`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R18) [[2]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fL24-R25)
* A new CRAN downloads badge was added to both `README.md` and `README.Rmd`, showing the total number of downloads for the `epitraxr` package from CRAN. This provides visibility into package usage. (`README.md`, `README.Rmd`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R18) [[2]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fL24-R25)