### PR TITLE
Enable public-name conversion in create_report_grouped_stats()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 docs
 *.Rcheck
 inst/doc
+scripts/test_format_files/
+scripts/test_scripts/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epitraxr
 Title: Manipulate 'EpiTrax' Data and Generate Reports
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: c(
     person("Andrew", "Pulsipher", , "pulsipher.a@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0773-3210")),

--- a/R/epitrax.R
+++ b/R/epitrax.R
@@ -790,7 +790,8 @@ epitrax_report_grouped_stats <- function(epitrax, is.public = FALSE) {
         diseases = report_diseases,
         y = epitrax$report_year,
         m = epitrax$report_month,
-        config = epitrax$config
+        config = epitrax$config,
+        is.public = is.public
     )
 
     # Add report to EpiTrax object

--- a/inst/tinytest/test_reports.R
+++ b/inst/tinytest/test_reports.R
@@ -352,6 +352,29 @@ expected_result$Group <- c("Respiratory", "Respiratory", "Uncategorized")
 expect_true(is.data.frame(result_with_na))
 expect_equal(result_with_na, expected_result)
 
+# Test with is.public = TRUE and missing Public_name column
+expect_warning(
+  result_no_public <- create_report_grouped_stats(data, diseases_no_group, 2024, 3, config, is.public = TRUE),
+  "no public names were provided"
+)
+
+# Test with is.public = TRUE and valid Public_name column
+diseases_public <- data.frame(
+  EpiTrax_name = c("Flu", "Measles", "COVID"),
+  Public_name = c("Alpha", "Bravo", "Charlie"),
+  Group_name = c("Respiratory", "Vaccine-Preventable", "Respiratory")
+)
+
+result_public <- create_report_grouped_stats(data, diseases_public, 2024, 3, config, is.public = TRUE)
+
+# Update expected result with public names
+expected_result$Disease <- c("Charlie", "Alpha", "Bravo")
+expected_result$Group <- c("Respiratory", "Respiratory", "Vaccine-Preventable")
+# - Sort expected result to match result_public order
+expected_result <- expected_result[order(expected_result$Group, expected_result$Disease), ]
+
+expect_equal(result_public, expected_result)
+
 
 # Test create_public_report_combined_month_ytd() -------------------------------
 

--- a/man/create_report_grouped_stats.Rd
+++ b/man/create_report_grouped_stats.Rd
@@ -4,7 +4,7 @@
 \alias{create_report_grouped_stats}
 \title{Create grouped disease statistics report}
 \usage{
-create_report_grouped_stats(data, diseases, y, m, config)
+create_report_grouped_stats(data, diseases, y, m, config, is.public = FALSE)
 }
 \arguments{
 \item{data}{Dataframe. Input data with columns:
@@ -25,6 +25,8 @@ missing, all diseases will be grouped under "Uncategorized".}
 \item{m}{Integer. Report month (1-12)}
 
 \item{config}{List. Report settings}
+
+\item{is.public}{Logical. If TRUE, uses public-facing disease names.}
 }
 \value{
 Dataframe with one row per disease containing:


### PR DESCRIPTION
This pull request adds support for generating public-facing disease reports by allowing the use of alternate, public-friendly disease names in the grouped statistics report. It introduces a new `is.public` parameter to the relevant functions, updates documentation, and adds tests to ensure correct behavior when public names are present or missing.

**Support for public-facing disease names:**

* Added an `is.public` parameter to `create_report_grouped_stats` and updated its usage in `epitrax_report_grouped_stats`, enabling the function to optionally use public-facing disease names if provided. [[1]](diffhunk://#diff-19e7f2f23e96ce42dec08d22a1c8a955e57a74d36326b1c71841908ef874f07bL404-R405) [[2]](diffhunk://#diff-31f40c6a16627b4919d8aeaaad78f4e369eabfedabfe6f60f463cda688c4965eL793-R794) [[3]](diffhunk://#diff-12333690efc6e9d8556172ace04538ef85533702495525d307dd7ca69186a12bL7-R7)
* Modified the merging logic in `create_report_grouped_stats` to replace disease names with public-facing names when `is.public` is `TRUE`, and to warn if the required column is missing. The function also now removes the `Public_name` column from output.
* Updated documentation for `create_report_grouped_stats` to describe the new `is.public` parameter and its behavior. [[1]](diffhunk://#diff-19e7f2f23e96ce42dec08d22a1c8a955e57a74d36326b1c71841908ef874f07bR372) [[2]](diffhunk://#diff-12333690efc6e9d8556172ace04538ef85533702495525d307dd7ca69186a12bR28-R29)

**Testing enhancements:**

* Added tests to ensure correct behavior when generating reports with and without public-facing disease names, including cases where the `Public_name` column is missing.